### PR TITLE
feat: planner scope management CLI commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,8 @@ import {
   type McpId,
 } from './mcp-registry.js';
 
+import { addPattern, listPatterns, removePattern, resetScope } from './planner-scope.js';
+
 const RESPONSE_LANGUAGE_PLACEHOLDER = '{{response_language}}';
 const USER_SKILL_LEVEL_PLACEHOLDER = '{{user_skill_level}}';
 const USER_KNOWN_TECH_XML_PLACEHOLDER = '{{user_known_tech_xml}}';
@@ -651,7 +653,106 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error: unknown) => {
+
+async function runPlannerScopeSubcommand(args: string[]): Promise<void> {
+  const subcommand = args[0];
+  
+  switch (subcommand) {
+    case 'list': {
+      const result = await listPatterns();
+      process.stdout.write('Planner scope patterns:\n');
+      for (const pattern of result.patterns) {
+        process.stdout.write(`  - ${pattern}\n`);
+      }
+      break;
+    }
+    
+    case 'add': {
+      const pattern = args[1];
+      if (!pattern) {
+        process.stderr.write('Error: Pattern argument required\n');
+        process.stderr.write('Usage: assistagents planner-scope add <glob> [--force]\n');
+        process.exitCode = 1;
+        return;
+      }
+      const force = args.includes('--force');
+      const result = await addPattern(pattern, force);
+      if (result.warning) {
+        process.stderr.write(`${result.warning}\n`);
+      }
+      if (!result.success) {
+        process.stderr.write(`Error: ${result.message}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write(`${result.message}\n`);
+      if (result.added) {
+        process.stdout.write('Note: Restart any active planner sessions to apply changes.\n');
+      }
+      break;
+    }
+    
+    case 'remove': {
+      const pattern = args[1];
+      if (!pattern) {
+        process.stderr.write('Error: Pattern argument required\n');
+        process.stderr.write('Usage: assistagents planner-scope remove <glob>\n');
+        process.exitCode = 1;
+        return;
+      }
+      const result = await removePattern(pattern);
+      if (!result.success) {
+        process.stderr.write(`Error: ${result.message}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write(`${result.message}\n`);
+      if (result.removed) {
+        process.stdout.write('Note: Restart any active planner sessions to apply changes.\n');
+      }
+      break;
+    }
+    
+    case 'reset': {
+      const result = await resetScope();
+      if (!result.success) {
+        process.stderr.write(`Error: ${result.message}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write(`${result.message}\n`);
+      process.stdout.write('Note: Restart any active planner sessions to apply changes.\n');
+      break;
+    }
+    
+    default:
+      process.stderr.write(`Unknown planner-scope subcommand: ${subcommand}\n`);
+      process.stderr.write('Available subcommands: list, add, remove, reset\n');
+      process.exitCode = 1;
+  }
+}
+
+async function runCli(): Promise<void> {
+  const args = process.argv.slice(2);
+  
+  // Check for planner-scope subcommand
+  if (args[0] === 'planner-scope') {
+    const subcommandArgs = args.slice(1);
+    if (subcommandArgs.length === 0) {
+      process.stderr.write('Error: planner-scope requires a subcommand\n');
+      process.stderr.write('Available subcommands: list, add, remove, reset\n');
+      process.exitCode = 1;
+      return;
+    }
+    await runPlannerScopeSubcommand(subcommandArgs);
+    return;
+  }
+  
+  // Default: run interactive setup
+  await main();
+}
+
+runCli().catch((error: unknown) => {
   const message = error instanceof Error ? error.message : String(error);
   process.stderr.write(`assistagents failed: ${message}\n`);
   process.exitCode = 1;

--- a/src/planner-scope.ts
+++ b/src/planner-scope.ts
@@ -1,0 +1,351 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { ensureDir, pathExists, writeFileAtomic } from './fs-utils.js';
+
+// Default scope pattern that cannot be removed
+export const DEFAULT_SCOPE = 'ai-docs/dev-plans/**.md';
+
+// Wide patterns that require --force
+export const WIDE_PATTERNS = ['**/*.md', '**/**.md', '*.md'];
+
+// Anchor markers in installed planner.md
+export const SCOPE_ANCHOR_BEGIN = '__assistagents_planner_md_scope_begin__';
+export const SCOPE_ANCHOR_END = '__assistagents_planner_md_scope_end__';
+
+export type PlannerScopeConfig = {
+  version: 1;
+  patterns: string[];
+};
+
+function getScopeConfigPath(): string {
+  const home = os.homedir();
+  return path.join(home, '.opencode', 'assistagents', 'planner-scope.json');
+}
+
+function getInstalledPlannerPath(): string {
+  const home = os.homedir();
+  return path.join(home, '.opencode', 'agents', 'build', 'planner.md');
+}
+
+export function getScopeConfigDir(): string {
+  return path.dirname(getScopeConfigPath());
+}
+
+export async function loadScopeConfig(): Promise<PlannerScopeConfig> {
+  const configPath = getScopeConfigPath();
+  
+  if (!(await pathExists(configPath))) {
+    return {
+      version: 1,
+      patterns: [DEFAULT_SCOPE],
+    };
+  }
+  
+  const content = await fs.readFile(configPath, 'utf8');
+  const config = JSON.parse(content) as PlannerScopeConfig;
+  
+  // Ensure default is always present
+  if (!config.patterns.includes(DEFAULT_SCOPE)) {
+    config.patterns.unshift(DEFAULT_SCOPE);
+  }
+  
+  return config;
+}
+
+export async function saveScopeConfig(config: PlannerScopeConfig): Promise<void> {
+  const configPath = getScopeConfigPath();
+  await ensureDir(getScopeConfigDir());
+  await writeFileAtomic(configPath, JSON.stringify(config, null, 2));
+}
+
+export type ValidationResult = {
+  valid: boolean;
+  error?: string;
+  warning?: string;
+  isWidePattern?: boolean;
+};
+
+export function validatePattern(pattern: string): ValidationResult {
+  const trimmed = pattern.trim();
+  
+  if (trimmed.length === 0) {
+    return { valid: false, error: 'Pattern cannot be empty' };
+  }
+  
+  // Check for absolute paths
+  if (path.isAbsolute(trimmed)) {
+    return { valid: false, error: 'Absolute paths are not allowed' };
+  }
+  
+  // Check for .. segments
+  if (trimmed.includes('..')) {
+    return { valid: false, error: 'Parent directory references (..) are not allowed' };
+  }
+  
+  // Check for .md extension
+  if (!trimmed.endsWith('.md')) {
+    return { valid: false, error: 'Pattern must end with .md extension' };
+  }
+  
+  // Check for wide patterns
+  if (WIDE_PATTERNS.includes(trimmed)) {
+    return { 
+      valid: false, 
+      error: `Pattern "${trimmed}" is too wide and could allow editing any markdown file`,
+      isWidePattern: true,
+    };
+  }
+  
+  return { valid: true };
+}
+
+export function validatePatternWithForce(pattern: string, force: boolean): ValidationResult {
+  const result = validatePattern(pattern);
+  
+  if (!result.valid && result.isWidePattern && force) {
+    return { 
+      valid: true, 
+      warning: `Warning: Wide pattern "${pattern}" allowed with --force`,
+      isWidePattern: true,
+    };
+  }
+  
+  return result;
+}
+
+export function normalizePattern(pattern: string): string {
+  return pattern.trim();
+}
+
+export function buildPermissionLines(patterns: string[]): string {
+  return patterns
+    .map((p) => `"${p}": allow`)
+    .join('\n');
+}
+
+export type ApplyResult = {
+  success: boolean;
+  error?: string;
+};
+
+
+export async function applyScopeToInstalledPlanner(patterns: string[]): Promise<ApplyResult> {
+  const plannerPath = getInstalledPlannerPath();
+  
+  if (!(await pathExists(plannerPath))) {
+    return {
+      success: false,
+      error: `Installed planner.md not found at ${plannerPath}. Run 'assistagents' setup first.`,
+    };
+  }
+  
+  const content = await fs.readFile(plannerPath, 'utf8');
+  const lines = content.split('\n');
+  
+  // Find all anchor pairs (should be 2: one for edit, one for apply_patch)
+  const anchorPairs: Array<{ startIdx: number; endIdx: number; indent: string }> = [];
+  
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line && line.includes(SCOPE_ANCHOR_BEGIN)) {
+      // Extract indent from the line
+      const indentMatch = line.match(/^(\s*)/);
+      const indent = indentMatch?.[1] ?? '';
+      
+      // Find the corresponding end anchor
+      for (let j = i + 1; j < lines.length; j++) {
+        const endLine = lines[j];
+        if (endLine && endLine.includes(SCOPE_ANCHOR_END)) {
+          anchorPairs.push({ startIdx: i, endIdx: j, indent });
+          break;
+        }
+      }
+    }
+  }
+  
+  if (anchorPairs.length === 0) {
+    return {
+      success: false,
+      error: `Anchors not found in ${plannerPath}. Your installation may be outdated. Run 'assistagents' setup to update.`,
+    };
+  }
+  
+  // Build new permission lines with proper indent
+  const permissionLines = buildPermissionLines(patterns);
+  const firstAnchor = anchorPairs[0];
+  if (!firstAnchor) {
+    return { success: false, error: 'No anchor pairs found' };
+  }
+  const indentedPermissionLines = permissionLines
+    .split('\n')
+    .map((line) => `${firstAnchor.indent}${line}`)
+    .join('\n');
+  
+  // Replace content between anchors (process from end to start to preserve indices)
+  const newLines = [...lines];
+  for (let i = anchorPairs.length - 1; i >= 0; i--) {
+    const anchor = anchorPairs[i];
+    if (anchor) {
+      const { startIdx, endIdx } = anchor;
+      // Remove lines between anchors (not including anchors themselves)
+      newLines.splice(startIdx + 1, endIdx - startIdx - 1, indentedPermissionLines);
+    }
+  }
+  
+  await writeFileAtomic(plannerPath, newLines.join('\n'));
+  
+  return { success: true };
+}
+
+export type AddResult = {
+  success: boolean;
+  added: boolean;
+  message: string;
+  warning?: string | undefined;
+};
+
+export async function addPattern(pattern: string, force: boolean): Promise<AddResult> {
+  const normalized = normalizePattern(pattern);
+  
+  const validation = validatePatternWithForce(normalized, force);
+  if (!validation.valid) {
+    return {
+      success: false,
+      added: false,
+      message: validation.error || 'Invalid pattern',
+    };
+  }
+  
+  const config = await loadScopeConfig();
+  
+  if (config.patterns.includes(normalized)) {
+    return {
+      success: true,
+      added: false,
+      message: `Pattern "${normalized}" is already in scope`,
+      warning: validation.warning,
+    };
+  }
+  
+  config.patterns.push(normalized);
+  config.patterns.sort((a, b) => {
+    // Default always first
+    if (a === DEFAULT_SCOPE) return -1;
+    if (b === DEFAULT_SCOPE) return 1;
+    return a.localeCompare(b);
+  });
+  
+  await saveScopeConfig(config);
+  
+  const applyResult = await applyScopeToInstalledPlanner(config.patterns);
+  if (!applyResult.success) {
+    return {
+      success: false,
+      added: false,
+      message: applyResult.error || 'Failed to apply scope to installed planner',
+    };
+  }
+  
+  return {
+    success: true,
+    added: true,
+    message: `Added "${normalized}" to planner scope`,
+    warning: validation.warning,
+  };
+}
+
+export type RemoveResult = {
+  success: boolean;
+  removed: boolean;
+  message: string;
+};
+
+export async function removePattern(pattern: string): Promise<RemoveResult> {
+  const normalized = normalizePattern(pattern);
+  
+  if (normalized === DEFAULT_SCOPE) {
+    return {
+      success: false,
+      removed: false,
+      message: `Cannot remove default pattern "${DEFAULT_SCOPE}"`,
+    };
+  }
+  
+  const config = await loadScopeConfig();
+  
+  const idx = config.patterns.indexOf(normalized);
+  if (idx === -1) {
+    return {
+      success: true,
+      removed: false,
+      message: `Pattern "${normalized}" is not in scope`,
+    };
+  }
+  
+  config.patterns.splice(idx, 1);
+  await saveScopeConfig(config);
+  
+  const applyResult = await applyScopeToInstalledPlanner(config.patterns);
+  if (!applyResult.success) {
+    return {
+      success: false,
+      removed: false,
+      message: applyResult.error || 'Failed to apply scope to installed planner',
+    };
+  }
+  
+  return {
+    success: true,
+    removed: true,
+    message: `Removed "${normalized}" from planner scope`,
+  };
+}
+
+export type ResetResult = {
+  success: boolean;
+  message: string;
+};
+
+export async function resetScope(): Promise<ResetResult> {
+  const config: PlannerScopeConfig = {
+    version: 1,
+    patterns: [DEFAULT_SCOPE],
+  };
+  
+  await saveScopeConfig(config);
+  
+  const applyResult = await applyScopeToInstalledPlanner(config.patterns);
+  if (!applyResult.success) {
+    return {
+      success: false,
+      message: applyResult.error || 'Failed to apply scope to installed planner',
+    };
+  }
+  
+  return {
+    success: true,
+    message: 'Reset planner scope to default',
+  };
+}
+
+export type ListResult = {
+  patterns: string[];
+};
+
+export async function listPatterns(): Promise<ListResult> {
+  const config = await loadScopeConfig();
+  return { patterns: config.patterns };
+}
+
+// Helper for testing: override home directory
+export function getPathsForHome(homeDir: string): {
+  configPath: string;
+  plannerPath: string;
+} {
+  return {
+    configPath: path.join(homeDir, '.opencode', 'assistagents', 'planner-scope.json'),
+    plannerPath: path.join(homeDir, '.opencode', 'agents', 'build', 'planner.md'),
+  };
+}

--- a/templates/agents/build/planner.md
+++ b/templates/agents/build/planner.md
@@ -23,10 +23,14 @@ permission:
     list: allow
     edit: 
         "*": deny
+        "__assistagents_planner_md_scope_begin__": deny
         "ai-docs/dev-plans/**.md": allow
+        "__assistagents_planner_md_scope_end__": deny
     apply_patch: 
         "*": deny
+        "__assistagents_planner_md_scope_begin__": deny
         "ai-docs/dev-plans/**.md": allow
+        "__assistagents_planner_md_scope_end__": deny
     question: allow
     webfetch: allow
     todoread: allow
@@ -105,7 +109,7 @@ permission:
 
   <tool_policy>
     <allowed>read, grep, glob, list, lsp, question, context7*, github-grep*, webfetch, todoread, todowrite, assist/research/* via task, read-only bash</allowed>
-    <write_scope>edit only for ai-docs/dev-plans/**.md</write_scope>
+    <write_scope>edit only for allowed scope patterns (manage via /planner-scope command)</write_scope>
     <forbidden>any changes to source code, dependencies, migrations, git state, or environment</forbidden>
   </tool_policy>
 

--- a/templates/commands/planner-scope.md
+++ b/templates/commands/planner-scope.md
@@ -1,0 +1,55 @@
+---
+description: Manage planner markdown scope patterns
+agent: build/dev
+---
+You are executing a slash command: /planner-scope.
+
+Goal: manage the list of allowed markdown file patterns that build/planner can edit or apply_patch.
+
+Inputs:
+- `$ARGUMENTS`: subcommand and arguments. Supported subcommands:
+  - `list` - show current scope patterns
+  - `add <glob>` - add a new pattern to scope
+  - `add <glob> --force` - add a wide pattern (like `**/*.md`) with force
+  - `remove <glob>` - remove a pattern from scope
+  - `reset` - reset scope to default (`ai-docs/dev-plans/**.md` only)
+
+Hard requirements:
+- Execute the `assistagents` CLI tool via bash to perform the actual operation.
+- Do not modify files directly; use the CLI.
+- If the CLI is not found, suggest the user run `npx -g @ozerohax/assistagents@latest planner-scope ...`.
+
+Process:
+
+1) Parse `$ARGUMENTS` to determine subcommand and parameters.
+
+2) Execute via bash:
+   - `assistagents planner-scope list`
+   - `assistagents planner-scope add <glob>`
+   - `assistagents planner-scope add <glob> --force`
+   - `assistagents planner-scope remove <glob>`
+   - `assistagents planner-scope reset`
+
+3) Report the result:
+   - For `list`: show all patterns.
+   - For `add`: confirm addition or show error.
+   - For `remove`: confirm removal or show error.
+   - For `reset`: confirm reset.
+
+Validation rules (enforced by CLI):
+- Patterns must end with `.md`.
+- Absolute paths are never allowed.
+- Parent directory references (`..`) are never allowed.
+- Wide patterns (`**/*.md`, `**/**.md`, `*.md`) require `--force` flag.
+- The default pattern `ai-docs/dev-plans/**.md` cannot be removed.
+
+Output format:
+- Print the CLI output.
+- If changes were made, remind user to restart any active planner sessions.
+
+Examples:
+- `/planner-scope list`
+- `/planner-scope add gsd-plans/**.md`
+- `/planner-scope add docs/**/*.md`
+- `/planner-scope remove gsd-plans/**.md`
+- `/planner-scope reset`

--- a/tests/agent-placeholders.test.ts
+++ b/tests/agent-placeholders.test.ts
@@ -245,3 +245,27 @@ test('markdown placeholder replacement supports inline tokens', () => {
     'src/cli.ts must replace inline placeholders using the same replacement map'
   );
 });
+
+test('planner template has scope management anchors', () => {
+  const plannerTemplate = readFileSync('templates/agents/build/planner.md', 'utf-8');
+  
+  // Check for anchor markers in edit permission block
+  assert.match(
+    plannerTemplate,
+    /"__assistagents_planner_md_scope_begin__": deny/,
+    'planner template must include scope begin anchor'
+  );
+  assert.match(
+    plannerTemplate,
+    /"__assistagents_planner_md_scope_end__": deny/,
+    'planner template must include scope end anchor'
+  );
+  
+  
+  // Verify there are 2 pairs of anchors (edit and apply_patch)
+  const beginMatches = plannerTemplate.match(/__assistagents_planner_md_scope_begin__/g);
+  const endMatches = plannerTemplate.match(/__assistagents_planner_md_scope_end__/g);
+  
+  assert.equal(beginMatches ? beginMatches.length : 0, 2, 'planner template must have 2 begin anchors (edit and apply_patch)');
+  assert.equal(endMatches ? endMatches.length : 0, 2, 'planner template must have 2 end anchors (edit and apply_patch)');
+});

--- a/tests/planner-scope-cli.test.ts
+++ b/tests/planner-scope-cli.test.ts
@@ -1,0 +1,274 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import { DEFAULT_SCOPE, SCOPE_ANCHOR_BEGIN, SCOPE_ANCHOR_END } from '../src/planner-scope.js';
+
+// Helper to run CLI with isolated HOME
+async function runCli(
+  args: string[],
+  tempHome: string
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  return new Promise((resolve) => {
+    const proc = spawn('node', ['dist/cli.js', ...args], {
+      env: { ...process.env, HOME: tempHome },
+      cwd: process.cwd(),
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      resolve({ stdout, stderr, exitCode: code });
+    });
+  });
+}
+
+// Helper to create minimal planner.md with anchors
+async function createMinimalPlanner(targetPath: string): Promise<void> {
+  const content = `---
+description: Test Planner
+permission:
+    edit: 
+        "*": deny
+        "${SCOPE_ANCHOR_BEGIN}": deny
+        "${DEFAULT_SCOPE}": allow
+        "${SCOPE_ANCHOR_END}": deny
+    apply_patch: 
+        "*": deny
+        "${SCOPE_ANCHOR_BEGIN}": deny
+        "${DEFAULT_SCOPE}": allow
+        "${SCOPE_ANCHOR_END}": deny
+---
+`;
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.writeFile(targetPath, content);
+}
+
+// Helper to read planner.md content
+async function readPlannerContent(plannerPath: string): Promise<string> {
+  try {
+    return await fs.readFile(plannerPath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+// Helper to read scope config
+async function readScopeConfig(configPath: string): Promise<unknown> {
+  try {
+    const content = await fs.readFile(configPath, 'utf8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+test('planner-scope list returns default when no config exists', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  
+  try {
+    const result = await runCli(['planner-scope', 'list'], tempDir);
+    
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes(DEFAULT_SCOPE));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope add updates config and planner.md', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  const configPath = path.join(tempDir, '.opencode', 'assistagents', 'planner-scope.json');
+  const plannerPath = path.join(tempDir, '.opencode', 'agents', 'build', 'planner.md');
+  
+  try {
+    await createMinimalPlanner(plannerPath);
+    
+    const result = await runCli(['planner-scope', 'add', 'gsd-plans/**.md'], tempDir);
+    
+    assert.equal(result.exitCode, 0, `Expected exit 0, got ${result.exitCode}. stderr: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Added "gsd-plans/**.md"'));
+    
+    // Check config
+    const config = await readScopeConfig(configPath) as { patterns: string[] };
+    assert.ok(config, 'Config should exist');
+    assert.ok(config.patterns.includes('gsd-plans/**.md'), 'Config should include new pattern');
+    
+    // Check planner.md was updated
+    const plannerContent = await readPlannerContent(plannerPath);
+    assert.ok(plannerContent.includes('"gsd-plans/**.md": allow'), 'Planner should include new allow line');
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope remove removes pattern from config and planner.md', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  const plannerPath = path.join(tempDir, '.opencode', 'agents', 'build', 'planner.md');
+  
+  try {
+    await createMinimalPlanner(plannerPath);
+    
+    // Add first
+    await runCli(['planner-scope', 'add', 'gsd-plans/**.md'], tempDir);
+    
+    // Then remove
+    const result = await runCli(['planner-scope', 'remove', 'gsd-plans/**.md'], tempDir);
+    
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('Removed "gsd-plans/**.md"'));
+    
+    // Check planner.md no longer has the pattern
+    const plannerContent = await readPlannerContent(plannerPath);
+    assert.ok(!plannerContent.includes('"gsd-plans/**.md": allow'), 'Planner should not include removed pattern');
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope remove cannot remove default pattern', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  
+  try {
+    const result = await runCli(['planner-scope', 'remove', DEFAULT_SCOPE], tempDir);
+    
+    assert.notEqual(result.exitCode, 0);
+    assert.ok(result.stderr.includes('Cannot remove default pattern'));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope reset returns to default only', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  const plannerPath = path.join(tempDir, '.opencode', 'agents', 'build', 'planner.md');
+  
+  try {
+    await createMinimalPlanner(plannerPath);
+    
+    // Add pattern
+    await runCli(['planner-scope', 'add', 'gsd-plans/**.md'], tempDir);
+    
+    // Reset
+    const result = await runCli(['planner-scope', 'reset'], tempDir);
+    
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('Reset planner scope to default'));
+    
+    // Check planner.md only has default
+    const plannerContent = await readPlannerContent(plannerPath);
+    assert.ok(!plannerContent.includes('"gsd-plans/**.md": allow'), 'Planner should not include removed pattern after reset');
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope add with wide pattern fails without --force', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  const plannerPath = path.join(tempDir, '.opencode', 'agents', 'build', 'planner.md');
+  
+  try {
+    await createMinimalPlanner(plannerPath);
+    
+    const result = await runCli(['planner-scope', 'add', '**/*.md'], tempDir);
+    
+    assert.notEqual(result.exitCode, 0);
+    assert.ok(result.stderr.includes('too wide'));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope add with wide pattern succeeds with --force', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  const plannerPath = path.join(tempDir, '.opencode', 'agents', 'build', 'planner.md');
+  
+  try {
+    await createMinimalPlanner(plannerPath);
+    
+    const result = await runCli(['planner-scope', 'add', '**/*.md', '--force'], tempDir);
+    
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('Added "**/*.md"'));
+    assert.ok(result.stderr.includes('Warning'));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope add rejects absolute paths even with --force', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  
+  try {
+    const result = await runCli(['planner-scope', 'add', '/tmp/x.md', '--force'], tempDir);
+    
+    assert.notEqual(result.exitCode, 0);
+    assert.ok(result.stderr.includes('Absolute'));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope add rejects .. even with --force', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  
+  try {
+    const result = await runCli(['planner-scope', 'add', '../x.md', '--force'], tempDir);
+    
+    assert.notEqual(result.exitCode, 0);
+    assert.ok(result.stderr.includes('..'));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope fails with error when anchors not found', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  const plannerPath = path.join(tempDir, '.opencode', 'agents', 'build', 'planner.md');
+  
+  try {
+    // Create planner without anchors
+    await fs.mkdir(path.dirname(plannerPath), { recursive: true });
+    await fs.writeFile(plannerPath, '---\ndescription: Old Planner\n---\n');
+    
+    const result = await runCli(['planner-scope', 'add', 'gsd-plans/**.md'], tempDir);
+    
+    assert.notEqual(result.exitCode, 0);
+    assert.ok(result.stderr.includes('Anchors not found'));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('planner-scope add does not duplicate existing pattern', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'planner-scope-test-'));
+  const plannerPath = path.join(tempDir, '.opencode', 'agents', 'build', 'planner.md');
+  
+  try {
+    await createMinimalPlanner(plannerPath);
+    
+    // Add pattern
+    await runCli(['planner-scope', 'add', 'gsd-plans/**.md'], tempDir);
+    
+    // Try to add again
+    const result = await runCli(['planner-scope', 'add', 'gsd-plans/**.md'], tempDir);
+    
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('already in scope'));
+    assert.ok(!result.stdout.includes('Added'));
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/planner-scope.test.ts
+++ b/tests/planner-scope.test.ts
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_SCOPE,
+  WIDE_PATTERNS,
+  validatePattern,
+  validatePatternWithForce,
+  normalizePattern,
+  buildPermissionLines,
+} from '../src/planner-scope.js';
+
+// Unit tests for validation logic
+
+test('validatePattern accepts valid md patterns', () => {
+  const validPatterns = [
+    'docs/**.md',
+    'docs/**/*.md',
+    'plans/*.md',
+    'ai-docs/dev-plans/**.md',
+    'gsd-plans/**.md',
+    'README.md',
+  ];
+
+  for (const pattern of validPatterns) {
+    const result = validatePattern(pattern);
+    assert.equal(result.valid, true, `Pattern "${pattern}" should be valid`);
+  }
+});
+
+test('validatePattern rejects non-md patterns', () => {
+  const invalidPatterns = [
+    'src/**',
+    'docs/**.txt',
+    '*.json',
+    'plans/',
+  ];
+
+  for (const pattern of invalidPatterns) {
+    const result = validatePattern(pattern);
+    assert.equal(result.valid, false, `Pattern "${pattern}" should be invalid`);
+    assert.ok(result.error?.includes('.md'), `Error should mention .md for "${pattern}"`);
+  }
+});
+
+test('validatePattern rejects absolute paths', () => {
+  // Note: Windows absolute paths like C:\... are only detected on Windows
+  // On Unix, path.isAbsolute('C:\...') returns false
+  const absolutePaths = [
+    '/tmp/x.md',
+    '/home/user/plans/*.md',
+  ];
+
+  for (const pattern of absolutePaths) {
+    const result = validatePattern(pattern);
+    assert.equal(result.valid, false, `Absolute path "${pattern}" should be invalid`);
+    assert.ok(result.error?.includes('Absolute'), `Error should mention absolute for "${pattern}"`);
+  }
+});
+
+test('validatePattern rejects parent directory references', () => {
+  const parentRefs = [
+    '../plans/*.md',
+    'docs/../plans/*.md',
+    './plans/../x.md',
+  ];
+
+  for (const pattern of parentRefs) {
+    const result = validatePattern(pattern);
+    assert.equal(result.valid, false, `Pattern with .. "${pattern}" should be invalid`);
+    assert.ok(result.error?.includes('..'), `Error should mention .. for "${pattern}"`);
+  }
+});
+
+test('validatePattern rejects empty patterns', () => {
+  const result = validatePattern('');
+  assert.equal(result.valid, false);
+  assert.ok(result.error?.includes('empty'));
+});
+
+test('validatePattern marks wide patterns with isWidePattern flag', () => {
+  for (const pattern of WIDE_PATTERNS) {
+    const result = validatePattern(pattern);
+    assert.equal(result.valid, false, `Wide pattern "${pattern}" should be invalid by default`);
+    assert.equal(result.isWidePattern, true, `Pattern "${pattern}" should be marked as wide`);
+  }
+});
+
+test('validatePatternWithForce allows wide patterns with force', () => {
+  for (const pattern of WIDE_PATTERNS) {
+    const result = validatePatternWithForce(pattern, true);
+    assert.equal(result.valid, true, `Wide pattern "${pattern}" should be valid with force`);
+    assert.equal(result.isWidePattern, true);
+    assert.ok(result.warning?.includes('--force'), `Should include --force warning for "${pattern}"`);
+  }
+});
+
+test('validatePatternWithForce rejects wide patterns without force', () => {
+  for (const pattern of WIDE_PATTERNS) {
+    const result = validatePatternWithForce(pattern, false);
+    assert.equal(result.valid, false, `Wide pattern "${pattern}" should be invalid without force`);
+  }
+});
+
+test('validatePatternWithForce still rejects absolute paths even with force', () => {
+  const result = validatePatternWithForce('/tmp/x.md', true);
+  assert.equal(result.valid, false, 'Absolute paths should be rejected even with force');
+});
+
+test('validatePatternWithForce still rejects .. even with force', () => {
+  const result = validatePatternWithForce('../x.md', true);
+  assert.equal(result.valid, false, '.. should be rejected even with force');
+});
+
+// Unit tests for normalizePattern
+
+test('normalizePattern trims whitespace', () => {
+  assert.equal(normalizePattern('  docs/**.md  '), 'docs/**.md');
+  assert.equal(normalizePattern('\tdocs/**.md\n'), 'docs/**.md');
+});
+
+// Unit tests for buildPermissionLines
+
+test('buildPermissionLines generates correct YAML lines', () => {
+  const patterns = ['ai-docs/dev-plans/**.md', 'docs/**.md'];
+  const lines = buildPermissionLines(patterns);
+  
+  assert.equal(lines, '"ai-docs/dev-plans/**.md": allow\n"docs/**.md": allow');
+});
+
+test('buildPermissionLines handles single pattern', () => {
+  const lines = buildPermissionLines([DEFAULT_SCOPE]);
+  assert.equal(lines, `"${DEFAULT_SCOPE}": allow`);
+});
+
+// Unit tests for constants
+
+test('DEFAULT_SCOPE is ai-docs/dev-plans/**.md', () => {
+  assert.equal(DEFAULT_SCOPE, 'ai-docs/dev-plans/**.md');
+});
+
+test('WIDE_PATTERNS includes expected patterns', () => {
+  assert.ok(WIDE_PATTERNS.includes('**/*.md'));
+  assert.ok(WIDE_PATTERNS.includes('**/**.md'));
+  assert.ok(WIDE_PATTERNS.includes('*.md'));
+  assert.equal(WIDE_PATTERNS.length, 3);
+});


### PR DESCRIPTION
## Summary

- Add CLI subcommands: `assistagents planner-scope list|add|remove|reset`
- Allow post-install management of planner's `.md` edit permissions without reinstall
- Add anchors in `planner.md` for in-place permission updates
- Add slash-command `/planner-scope` for build/dev agent

## Changes

### New files
- `src/planner-scope.ts` — core logic for scope management
- `templates/commands/planner-scope.md` — slash-command template

### Modified files
- `src/cli.ts` — CLI routing for planner-scope subcommands
- `templates/agents/build/planner.md` — anchors for managed permissions

### Tests
- `tests/planner-scope.test.ts` — unit tests (14 tests)
- `tests/planner-scope-cli.test.ts` — integration tests (11 tests)
- `tests/agent-placeholders.test.ts` — anchor verification (1 test)

## Validation rules

| Pattern | Without --force | With --force |
|---------|-----------------|--------------|
| `docs/**.md` | ✅ Allowed | ✅ Allowed |
| `**/*.md` | ❌ Blocked (wide) | ✅ Allowed + warning |
| `/tmp/x.md` | ❌ Blocked (absolute) | ❌ Blocked (always) |
| `../x.md` | ❌ Blocked (..) | ❌ Blocked (always) |

## Test plan

```bash
npm run typecheck  # OK
npm test           # 41/42 PASS (1 unrelated fail)
npm run build      # OK
```

## Documentation

- Plan: `ai-docs/dev-plans/2026-02-26-planner-scope-management.md`
- Test report: `ai-docs/reports/test-reports/2026-02-26-planner-scope-management.md`
- Code review: `ai-docs/reports/2026-02-26-planner-scope-code-review.md`